### PR TITLE
Thread SearchPath through expand_includes instead of recreating it per-call

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2385,20 +2385,27 @@ pub fn table_file(path: &Path) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
 }
 
 pub fn table_expanded(file: &Path) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
-    let search_path = &SearchPath::new_or("LOUIS_TABLE_PATH", ".");
-    let path = search_path.find_file(file);
-    match path {
+    let search_path = SearchPath::new_or("LOUIS_TABLE_PATH", ".");
+    table_expanded_with(file, &search_path)
+}
+
+fn table_expanded_with(
+    file: &Path,
+    search_path: &SearchPath,
+) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
+    match search_path.find_file(file) {
         Some(path) => {
             let rules = table_file(path.as_path())?;
-            let rules = expand_includes(rules)?;
-            Ok(rules)
+            expand_includes(rules, search_path)
         }
-        _ => Err(vec![TableError::TableNotFound(file.into())]),
+        None => Err(vec![TableError::TableNotFound(file.into())]),
     }
 }
 
-fn expand_include(rule: AnchoredRule) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
-    let search_path = &SearchPath::new_or("LOUIS_TABLE_PATH", ".");
+fn expand_include(
+    rule: AnchoredRule,
+    search_path: &SearchPath,
+) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
     match rule.rule {
         Rule::Include { ref file } => {
             let path = Path::new(file);
@@ -2419,17 +2426,19 @@ fn expand_include(rule: AnchoredRule) -> Result<Vec<AnchoredRule>, Vec<TableErro
             let path = search_path
                 .find_file(path)
                 .ok_or(vec![TableError::TableNotFound(path.into())])?;
-            let rules = table_expanded(&path)?;
-            Ok(rules)
+            table_expanded_with(&path, search_path)
         }
         _ => Ok(vec![rule]),
     }
 }
 
-pub fn expand_includes(rules: Vec<AnchoredRule>) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
+pub fn expand_includes(
+    rules: Vec<AnchoredRule>,
+    search_path: &SearchPath,
+) -> Result<Vec<AnchoredRule>, Vec<TableError>> {
     let (rules, errors): (Vec<_>, Vec<_>) = rules
         .into_iter()
-        .map(expand_include)
+        .map(|r| expand_include(r, search_path))
         .partition(Result::is_ok);
     let rules: Vec<_> = rules.into_iter().flat_map(Result::unwrap).collect();
     let errors: Vec<_> = errors.into_iter().flat_map(Result::unwrap_err).collect();

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,8 @@ use std::{collections::HashMap, path::PathBuf};
 
 use enumset::{EnumSet, EnumSetType};
 
+use search_path::SearchPath;
+
 use crate::{
     parser::{self, Direction, TableError},
     translator::{self, DisplayTable, TranslationPipeline},
@@ -100,11 +102,12 @@ impl<'a> TestMatrix<'a> {
     }
 
     fn display_table(&self, direction: Direction) -> Result<DisplayTable, TestError> {
+        let search_path = SearchPath::new_or("LOUIS_TABLE_PATH", ".");
         let display_rules = match self.display {
             Some(Display::Simple(path)) => parser::table_expanded(path.as_path())?,
             Some(Display::Inline(text)) => {
                 let rules = parser::table(text, None)?;
-                parser::expand_includes(rules)?
+                parser::expand_includes(rules, &search_path)?
             }
             Some(Display::List(paths)) => {
                 let mut rules = Vec::new();
@@ -123,6 +126,7 @@ impl<'a> TestMatrix<'a> {
         table: &Table,
         direction: Direction,
     ) -> Result<TranslationPipeline, TestError> {
+        let search_path = SearchPath::new_or("LOUIS_TABLE_PATH", ".");
         let rules = match table {
             Table::Simple(path) => parser::table_expanded(path.as_path())?,
             Table::List(paths) => {
@@ -134,7 +138,7 @@ impl<'a> TestMatrix<'a> {
             }
             Table::Inline(text) => {
                 let rules = parser::table(text, None)?;
-                parser::expand_includes(rules)?
+                parser::expand_includes(rules, &search_path)?
             }
             Table::Query(..) => return Err(TestError::NotImplemented("Table queries".to_string())),
         };

--- a/src/translator/table/primary.rs
+++ b/src/translator/table/primary.rs
@@ -855,6 +855,8 @@ impl PrimaryTable {
 mod tests {
     use super::*;
 
+    use search_path::SearchPath;
+
     use crate::parser::{RuleParser, expand_includes};
 
     fn parse_rule(source: &str) -> AnchoredRule {
@@ -1278,7 +1280,7 @@ mod tests {
             parse_rule("nocross always fff 456"),
             parse_rule("space \\s 0"),
         ];
-        let rules = expand_includes(rules).unwrap();
+        let rules = expand_includes(rules, &SearchPath::new_or("LOUIS_TABLE_PATH", ".")).unwrap();
         let context = TableContext::compile(&rules).unwrap();
         let table =
             PrimaryTable::compile(&rules, Direction::Forward, TranslationStage::Main, &context)


### PR DESCRIPTION
`expand_include` and `expand_includes` previously each called `SearchPath::new_or("LOUIS_TABLE_PATH", ".")` independently, so the search path was reconstructed on every recursive include directive. This introduces `table_expanded_with` and threads `&SearchPath` through both functions instead.

Callers in `test.rs` and `translator/table/primary.rs` updated accordingly.